### PR TITLE
Added how to build the apps on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,23 @@ Powered by [Ditto](https://www.ditto.live/).
 - [iOS Download](https://apps.apple.com/us/app/ditto-inventory/id1449905935)
 - [Android Download](https://play.google.com/store/apps/details?id=live.ditto.inventory)
 
+
+## How to build the apps
+
+### iOS
+
+1. Run `cp .env.template .env` at the root directory
+1. Edit `.env` to add environment variables
+1. Open the app project on Xcode and clean (<kbd>Command</kbd> + <kbd>Shift</kbd> + <kbd>K</kbd>)
+1. Build (<kbd>Command</kbd> + <kbd>B</kbd>)
+    - This will generate `Env.swift`
+
+### Android
+
+1. Open `/Android/gradle.properties` and add environment variables
+1. Build the app normally
+
+
 ## License
 
 MIT

--- a/iOS/Inventory.xcodeproj/project.pbxproj
+++ b/iOS/Inventory.xcodeproj/project.pbxproj
@@ -155,12 +155,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = E3ED324E20E439FF005FC8B1 /* Build configuration list for PBXNativeTarget "Inventory" */;
 			buildPhases = (
+				CCE28738298A561F00BAFC48 /* Generate Env.swift */,
 				B035A5BC7A180CCCDD211B9E /* [CP] Check Pods Manifest.lock */,
 				E3ED323820E439FD005FC8B1 /* Sources */,
 				E3ED323920E439FD005FC8B1 /* Frameworks */,
 				E3ED323A20E439FD005FC8B1 /* Resources */,
 				CC7551AF25D5251100007A3F /* Embed Frameworks */,
-				CCE28738298A561F00BAFC48 /* Generate Env.swift */,
 			);
 			buildRules = (
 			);


### PR DESCRIPTION
Closes #16


- `.env`, `Env.swift`, and `gradle.properties` are git-ignored and need to continue that way because they contain environment variables.
- The environment variables are listed on the notion page, which only Ditto members have access: https://www.notion.so/getditto/Environment-Variables-78261e05a2b44a299ee388f06e9ff86a


⚠️ Please clean/restart the Xcode project before testing this.