### PR TITLE
Fix 'Generate Env.swift' script

### DIFF
--- a/iOS/Inventory.xcodeproj/project.pbxproj
+++ b/iOS/Inventory.xcodeproj/project.pbxproj
@@ -155,12 +155,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = E3ED324E20E439FF005FC8B1 /* Build configuration list for PBXNativeTarget "Inventory" */;
 			buildPhases = (
+				CCE28738298A561F00BAFC48 /* Generate Env.swift */,
 				B035A5BC7A180CCCDD211B9E /* [CP] Check Pods Manifest.lock */,
 				E3ED323820E439FD005FC8B1 /* Sources */,
 				E3ED323920E439FD005FC8B1 /* Frameworks */,
 				E3ED323A20E439FD005FC8B1 /* Resources */,
 				CC7551AF25D5251100007A3F /* Embed Frameworks */,
-				CCE28738298A561F00BAFC48 /* Generate Env.swift */,
 			);
 			buildRules = (
 			);


### PR DESCRIPTION
- Similar to https://github.com/getditto/demoapp-skyservice/pull/26, this will fix the issue where the `Env.swift` won't be generated for the first build.