### PR TITLE
Fixing crash when quantity updated and item row is offscreen

### DIFF
--- a/iOS/Inventory/MainViewController.swift
+++ b/iOS/Inventory/MainViewController.swift
@@ -84,8 +84,8 @@ final class MainViewController: UIViewController {
         tableView.reloadRows(at: indexPaths, with: .automatic)
 
         indexPaths.forEach { indexPath in
-            let cell = tableView.cellForRow(at: indexPath) as! ItemTableViewCell
-            cell.animateBackground()
+            let cell = tableView.cellForRow(at: indexPath) as? ItemTableViewCell
+            cell?.animateBackground()
         }
     }
 


### PR DESCRIPTION
On an iPhone SE (or other smaller screened device) when a remote device updates a quantity and it syncs, the update to the bottom rows of the table that are offscreen causing the app to crash.

This fixes that.