### PR TITLE
adding faster animations

### DIFF
--- a/iOS/Inventory/MainViewController.swift
+++ b/iOS/Inventory/MainViewController.swift
@@ -79,10 +79,10 @@ final class MainViewController: UIViewController {
     }
 
     private func updateViewFor(indices: [Int]) {
-
         let indexPaths = indices.map { IndexPath(row: $0, section: 0) }
-        tableView.reloadRows(at: indexPaths, with: .automatic)
-
+        UIView.performWithoutAnimation {
+            tableView.reloadRows(at: indexPaths, with: .automatic)
+        }
         indexPaths.forEach { indexPath in
             let cell = tableView.cellForRow(at: indexPath) as? ItemTableViewCell
             cell?.animateBackground()


### PR DESCRIPTION
Animations are slow because of 

```swift
tableView.reloadRows(at: indexPaths, with: .automatic)
```

So we now reduce the default reload animation with:

```swift
UIView.performWithoutAnimation {
  tableView.reloadRows(at: indexPaths, with: .automatic)
}
```