### PR TITLE
update ditto version

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -58,7 +58,7 @@ android {
 }
 
 dependencies {
-    implementation("live.ditto:ditto:4.4.4")
+    implementation("live.ditto:ditto:4.5.4")
 
 
     // Load Presence Viewer from an .aar library file

--- a/iOS/Inventory.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/Inventory.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "cc825b447b6292cc0a4a2f7e25d4fae0e3bfb1a8",
-        "version" : "4.4.4"
+        "revision" : "b7ff3bb584798818f56d1488a9176801cfbe6ce9",
+        "version" : "4.5.4"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "a902f1823a7ff3c9ab2fba0f992396b948eda307",
-        "version" : "1.0.5"
+        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
+        "version" : "1.1.0"
       }
     }
   ],


### PR DESCRIPTION
Update to v4.5, then will push update to app store. This will be a transition period for users to update to v4.5 so when we publish the DQL version it will reduce the risk of breaking.