### PR TITLE
Fix UI overlap with ActionBar on Android 15

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "live.ditto.inventory"
         minSdkVersion 26
         targetSdkVersion 35
-        versionCode 59
-        versionName "1"
+        versionCode 60
+        versionName "1.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/Android/app/src/main/java/live/ditto/inventory/DittoInfoListActivity.kt
+++ b/Android/app/src/main/java/live/ditto/inventory/DittoInfoListActivity.kt
@@ -11,6 +11,9 @@ import android.widget.ArrayAdapter
 import android.widget.ListView
 import android.widget.TextView
 import androidx.core.content.pm.PackageInfoCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 
 class DittoInfoListActivity : AppCompatActivity() {
 
@@ -30,13 +33,20 @@ class DittoInfoListActivity : AppCompatActivity() {
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         title = "Ditto Info"
 
+        listView = findViewById(R.id.ditto_info_list_view)
+        ViewCompat.setOnApplyWindowInsetsListener(listView) { view, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            view.updatePadding(top = insets.top)
+            windowInsets
+        }
+
         val info = applicationContext.packageManager.getPackageInfo(application.packageName, PackageManager.GET_ACTIVITIES)
         val version = PackageInfoCompat.getLongVersionCode(info).toString()
         val appVersionTextView = findViewById<TextView>(R.id.app_version_text_view)
         appVersionTextView.text = "App Version: $version"
 
         listView = findViewById(R.id.ditto_info_list_view)
-        val items = arrayOf("Ditto SDK Info")
+        val items = arrayOf("Ditto SDK Detail")
         val adapter = ArrayAdapter(this, android.R.layout.simple_list_item_1, items)
         listView.adapter = adapter
         listView.setOnItemClickListener { _, _, position, _ ->

--- a/Android/app/src/main/java/live/ditto/inventory/DittoSDKInfoActivity.kt
+++ b/Android/app/src/main/java/live/ditto/inventory/DittoSDKInfoActivity.kt
@@ -6,6 +6,9 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.MenuItem
 import android.widget.TextView
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 
 class DittoSDKInfoActivity : AppCompatActivity() {
 
@@ -24,6 +27,12 @@ class DittoSDKInfoActivity : AppCompatActivity() {
         title = "Ditto SDK Info"
 
         val textView = findViewById<TextView>(R.id.ditto_sdk_info_text_view)
+
+        ViewCompat.setOnApplyWindowInsetsListener(textView) { view, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            view.updatePadding(top = insets.top)
+            windowInsets
+        }
 
         intent.getStringExtra("sdkInfo")?.let { sdkInfo ->
             val platform = sdkInfo.take(3)

--- a/Android/app/src/main/java/live/ditto/inventory/MainActivity.kt
+++ b/Android/app/src/main/java/live/ditto/inventory/MainActivity.kt
@@ -25,6 +25,9 @@ import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.launch
 import live.ditto.transports.DittoSyncPermissions
 import java.util.Locale
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 
 class MainActivity : AppCompatActivity(), DittoManager.ItemUpdateListener {
     private lateinit var recyclerView: RecyclerView
@@ -34,6 +37,16 @@ class MainActivity : AppCompatActivity(), DittoManager.ItemUpdateListener {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        val recyclerView = findViewById<RecyclerView>(R.id.recyclerView)
+        ViewCompat.setOnApplyWindowInsetsListener(recyclerView) { view, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            view.updatePadding(
+                top = insets.top,
+                bottom = insets.bottom
+            )
+            windowInsets
+        }
 
         checkLocationPermission()
 

--- a/Android/app/src/main/res/layout/activity_ditto_info_list.xml
+++ b/Android/app/src/main/res/layout/activity_ditto_info_list.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout 
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -11,6 +12,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginBottom="32dp"
+        android:clipToPadding="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/Android/app/src/main/res/layout/activity_ditto_sdk_info.xml
+++ b/Android/app/src/main/res/layout/activity_ditto_sdk_info.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout 
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -8,9 +9,13 @@
 
     <TextView
         android:id="@+id/ditto_sdk_info_text_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         android:layout_margin="16dp"
-        android:textSize="16sp" />
+        android:textSize="16sp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Android/app/src/main/res/layout/activity_main.xml
+++ b/Android/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout 
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -7,7 +9,12 @@
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:clipToPadding="false"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
# User description
### Summary
Fix layout issues where list items were hidden behind the ActionBar on Android 15 devices.

### Cause
Android 15 (API 35) enforces edge-to-edge display by default, causing app content to render behind system bars.

### Changes
- Added `WindowInsets` handling to `MainActivity`, `DittoInfoListActivity`, and `DittoSDKInfoActivity`
- Updated ConstraintLayout constraints in XML layout files
- Added `clipToPadding="false"` to scrollable views

### Screenshots
|Before fix|This PR|
|--|--|
|<img width="1080" height="2400" alt="share_2484531426180268550" src="https://github.com/user-attachments/assets/d43d2f35-7fbe-4044-bba0-c38c1ed78dc0" />|<img width="1080" height="2400" alt="Screenshot_20251211-174454" src="https://github.com/user-attachments/assets/f3465d59-5005-463f-80c0-b78f2837a28d" />|

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Implements edge-to-edge display support to prevent UI components from overlapping with system bars on Android 15. Updates <code>MainActivity</code>, <code>DittoInfoListActivity</code>, and <code>DittoSDKInfoActivity</code> to dynamically handle window insets and adjust view padding accordingly.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/getditto/demoapp-inventory/68?tool=ast&topic=Inset+Handling>Inset Handling</a>
        </td><td>Apply <code>WindowInsets</code> listeners to <code>RecyclerView</code>, <code>ListView</code>, and <code>TextView</code> components to dynamically adjust padding based on system bar dimensions.<details><summary>Modified files (3)</summary><ul><li>Android/app/src/main/java/live/ditto/inventory/DittoInfoListActivity.kt</li>
<li>Android/app/src/main/java/live/ditto/inventory/DittoSDKInfoActivity.kt</li>
<li>Android/app/src/main/java/live/ditto/inventory/MainActivity.kt</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alabeau@gmail.com</td><td>updated-for-Android-fi...</td><td>May 17, 2025</td></tr>
<tr><td>raj.ramsaroop1@accessc...</td><td>Fix-UI-lint-warnings</td><td>January 29, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/getditto/demoapp-inventory/68?tool=ast&topic=Layout+Adjustments>Layout Adjustments</a>
        </td><td>Modify XML layout constraints and set <code>clipToPadding="false"</code> to ensure scrollable content renders correctly behind system bars without being obscured.<details><summary>Modified files (4)</summary><ul><li>Android/app/build.gradle</li>
<li>Android/app/src/main/res/layout/activity_ditto_info_list.xml</li>
<li>Android/app/src/main/res/layout/activity_ditto_sdk_info.xml</li>
<li>Android/app/src/main/res/layout/activity_main.xml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shunsuke@ditto.com</td><td>Updated-Ditto-version-...</td><td>November 27, 2025</td></tr>
<tr><td>alabeau@gmail.com</td><td>updated-for-android-fo...</td><td>June 10, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/getditto/demoapp-inventory/68?tool=ast>(Baz)</a>.