### PR TITLE
Migrate ditto.live links to ditto.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Demo app for showcasing Ditto's real-time sync and Conflict Resolution through t
 
 This inventory demo showcases the smoothness of Ditto's sync and conflict resolution, and how counters work with Ditto. You can also open up the Presence Viewer to see all existing devices and connections in the mesh.
 
-Powered by [Ditto](https://www.ditto.live/).
+Powered by [Ditto](https://www.ditto.com/).
 
 For support, please contact Ditto Support (<support@ditto.com>).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This inventory demo showcases the smoothness of Ditto's sync and conflict resolu
 
 Powered by [Ditto](https://www.ditto.live/).
 
-For support, please contact Ditto Support (<support@ditto.live>).
+For support, please contact Ditto Support (<support@ditto.com>).
 
 - [Demo Video](https://www.youtube.com/watch?v=1P2bKEJjdec)
 - [iOS Download](https://apps.apple.com/us/app/ditto-inventory/id1449905935)


### PR DESCRIPTION
## Summary
- Updates README support contact from `support@ditto.live` to `support@ditto.com`.
- Updates Powered-by-Ditto link from `https://www.ditto.live/` to `https://www.ditto.com/`.