### PR TITLE
Android: target API 36 (Android 16) for Play compliance

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -30,7 +30,7 @@ android {
     defaultConfig {
         applicationId "live.ditto.inventory"
         minSdkVersion 26
-        targetSdkVersion 36
+        targetSdk 36
         versionCode 60
         versionName "1.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -25,12 +25,12 @@ def dittoEnv(String key) {
 
 android {
 
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         applicationId "live.ditto.inventory"
         minSdkVersion 26
-        targetSdkVersion 35
+        targetSdkVersion 36
         versionCode 60
         versionName "1.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
## Problem
Google Play requires apps to target within one year of the latest Android release. From **Aug 30, 2026**, apps still on API 35 (our current level) can't ship updates.

## Solution
Bump `compileSdk` and `targetSdkVersion` **35 → 36** (Android 16). AGP 8.9.2 / Gradle 8.11.1 already support it; `clean assembleDebug` passes and the merged manifest shows `targetSdkVersion="36"`.

Stacked on #73 (base `upgrade-ditto-sdk-v5`) since both touch `Android/app/build.gradle`; retarget to `main` once #73 merges.

## ⚠️ Needs testing: edge-to-edge (not verified yet)
Targeting API 36 fully enforces **edge-to-edge** (the opt-out is removed), so app content draws under the status and navigation bars. This is a common Android gotcha — UI can end up clipped or hidden behind the system bars.

**This has not been tested on an Android 16 device/emulator yet** (build-verified only). Before merge, please launch on API 36 and confirm nothing is obscured: the top app bar, the item list, the +/− buttons, and the Information / Ditto Tools / SDK-info screens. The app already sets `WindowInsets` listeners in several activities, but that needs to be confirmed under enforced edge-to-edge.